### PR TITLE
Corrected Player online check

### DIFF
--- a/src/main/java/com/plugish/woominecraft/WooMinecraft.java
+++ b/src/main/java/com/plugish/woominecraft/WooMinecraft.java
@@ -153,8 +153,8 @@ public final class WooMinecraft extends JavaPlugin {
 			String playerName = playerNames.next();
 
 			@SuppressWarnings( "deprecation" )
-			Player player = Bukkit.getServer().getPlayer( playerName );
-			if ( ! player.isOnline() ) {
+			Player player = Bukkit.getServer().getPlayerExact( playerName );
+			if ( ! (player == null) ) {
 				continue;
 			}
 

--- a/src/main/java/com/plugish/woominecraft/WooMinecraft.java
+++ b/src/main/java/com/plugish/woominecraft/WooMinecraft.java
@@ -154,7 +154,7 @@ public final class WooMinecraft extends JavaPlugin {
 
 			@SuppressWarnings( "deprecation" )
 			Player player = Bukkit.getServer().getPlayerExact( playerName );
-			if ( ! (player == null) ) {
+			if (player == null) {
 				continue;
 			}
 


### PR DESCRIPTION
Issue: When processing donations to players who are not online, the plugin throws a NullPointer Exception and stops processing

Cause: in public boolean check(), players online status is requested by checking whether getServer().getPlayer("name").isOnline() returns true. According to the Bukkit documentation, getServer().getPlayer("name") returns a player (if online), otherwise NULL.
The correct way of telling if a player is online is to check if getServer().getPlayer("name") returns null.

BTW: getServer().getPlayerExact("name") is better than getServer().getPlayer("name"), because getPlayer() will also return a player if only a part of the name is matching