### PR TITLE
Clarifies purpose of key

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,8 @@ update_interval: 1500
 url: "http://playground.dev"
 
 # This must match the WordPress key in your admin panel for WooMinecraft
+# This is a key that YOU set, both needing to be identical in the admin panel
+# and in this config file
 # For security purposes, you MUST NOT leave this empty.
 key: ""
 


### PR DESCRIPTION
Prevents users from asking or stating that their key is empty.

Helps out to prevent issues like #118