### PR TITLE
1.16.4/5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ WordPress side of things, we allow you to specify commands for product variation
 ![WooMinecraft Logo](https://raw.githubusercontent.com/WooMinecraft/WooMinecraft/master/src/main/resources/wmc-logo.jpg)
 
 ## IMPORTANT
-This build supports only **Minecraft Spigot 1.12.2**
+This build supports only **Minecraft Spigot 1.16.4/5**
 
 If in your config you are using the **/shop** path as your URL, you must NOT use that going forward. Your host MUST support
 access to the WordPress Rest API. If they do not, you should consider changing hosts.
@@ -63,6 +63,10 @@ Since this plugin is GPL and entirely opensource, we cannot be sure how you will
 You'll need the WordPress plugin for this MC Plugin to work - you can [get it here](https://github.com/WooMinecraft/woominecraft-wp).
 
 ## Changelog
+
+##1.2.1
+* Disabled legacy support, "should still work on 1.12 and below(untested)"
+* Update spigot api to 1.14.4+
 
 ## 1.2.0
 * Tested on Spigot 1.12.2

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>${spigotVersion}-R0.1-SNAPSHOT</version>
+            <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ version: ${project.version}
 authors: [JerryWood, TekkitCommando, Phillmac]
 description: ${project.description}
 website:  http://woominecraft.com
+api-version: 1.13
 
 commands:
   woo:


### PR DESCRIPTION

tested on 1.16.4/5
no errors