### PR TITLE
Reworked woo command

### DIFF
--- a/src/main/java/com/plugish/woominecraft/WooCommand.java
+++ b/src/main/java/com/plugish/woominecraft/WooCommand.java
@@ -1,50 +1,85 @@
 package com.plugish.woominecraft;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-public class WooCommand implements CommandExecutor {
+public class WooCommand implements TabExecutor {
 
-	public static WooMinecraft plugin = WooMinecraft.instance;
-	private static String chatPrefix = ChatColor.DARK_PURPLE + "[" + ChatColor.WHITE + "WooMinecraft" + ChatColor.DARK_PURPLE + "] " + ChatColor.DARK_PURPLE + "";
+    public WooMinecraft plugin = WooMinecraft.instance;
+    private final String chatPrefix = ChatColor.translateAlternateColorCodes('&', "&5[&fWooMinecraft&5] ");
 
-	@Override
-	public boolean onCommand( CommandSender sender, Command command, String label, String[] args ) {
-		if ( command.getName().equalsIgnoreCase( "woo" ) && args.length == 0 ) {
-			if ( sender.hasPermission( "woo.admin" ) || sender.isOp() ) {
-				sender.sendMessage( chatPrefix + " " + plugin.getLang( "general.avail_commands" ) + ": /woo check" );
-			} else {
-				sender.sendMessage( chatPrefix + " " + plugin.getLang( "general.not_authorized" ) );
-			}
-		} else if ( command.getName().equalsIgnoreCase( "woo" ) && args.length == 1 ) {
-			if ( args[ 0 ].equalsIgnoreCase( "check" ) ) {
-				if ( sender.hasPermission( "woo.admin" ) || sender.isOp() ) {
+    // Hashmap for storing subcommand names and permissions for them
+    private final HashMap<String, String> subCommands = new HashMap<>();
 
-					try {
-						String msg;
-						boolean checkResults = plugin.check();
+    public WooCommand() {
+        // add future subcommands here for automatic tab completion
+        subCommands.put("check", "woo.admin");
+    }
 
-						if ( !checkResults ) {
-							msg = chatPrefix + " " + plugin.getLang( "general.none_avail" );
-						} else {
-							msg = chatPrefix + " " + plugin.getLang( "general.processed" );
-						}
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            if (sender.hasPermission("woo.admin")) {
+                sender.sendMessage(chatPrefix + plugin.getLang("general.avail_commands") + ": /woo check");
+            } else {
+                sender.sendMessage(chatPrefix + plugin.getLang("general.not_authorized"));
+            }
+            return true;
+        } else if (args.length == 1) {
+            if (args[0].equalsIgnoreCase("check")) {
+                checkSubcommand(sender);
+            } else {
+                sender.sendMessage(chatPrefix + "Usage: /woo check");
+            }
+            return true;
+        }
+        sender.sendMessage(chatPrefix +"Usage: /woo check");
+        return true;
+    }
 
-						sender.sendMessage( msg );
-					} catch ( Exception e ) {
-						plugin.getLogger().warning( e.getMessage() );
-						e.printStackTrace();
-					}
-				} else {
-					String msg = plugin.getLang( "general.not_authorized" ).replace( "&", "\u00A7" );
-					sender.sendMessage( msg );
-				}
-			} else {
-				sender.sendMessage( "Usage: /woo check" );
-			}
-		}
-		return true;
-	}
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String s, String[] args) {
+        List<String> completions = new ArrayList<>();
+
+        // only care about first argument
+        if (args.length != 1)
+            return null;
+
+        for (Map.Entry<String, String> subCommand : subCommands.entrySet()) {
+            if (subCommand.getKey().startsWith(args[0]) && sender.hasPermission(subCommand.getValue()))
+                completions.add(subCommand.getKey());
+        }
+        return completions;
+    }
+
+    private void checkSubcommand(CommandSender sender) {
+        if (!sender.hasPermission("woo.admin")) {
+            String msg = chatPrefix + ChatColor.translateAlternateColorCodes('&', plugin.getLang("general.not_authorized"));
+            sender.sendMessage(msg);
+            return;
+        }
+        // Run check off the main thread
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                String msg = chatPrefix+" ";
+                if (plugin.check()) {
+                    msg = msg + plugin.getLang("general.processed");
+                } else {
+                    msg = msg + plugin.getLang("general.none_avail");
+                }
+                sender.sendMessage(msg);
+            } catch (Exception e) {
+                // send feedback for the sender
+                sender.sendMessage(chatPrefix+ChatColor.RED+e.getMessage());
+                e.printStackTrace();
+            }
+        });
+    }
 }


### PR DESCRIPTION
Added easily expandable tab completion
Got rid of static fields as command object is created anyway in main class to register the command
Moved things around to improve code readability
Added lambda to run blocking web request async
Added sender feedback in case check fails
Added sender feedback when trying to put more than 1 argument in the command
Removed redundant checks for op as op is set to get woo.admin automatically in plugin.yml
Removed redundant checks for command name as the code only runs for command that it's registered for

Seems to be everything, enjoy!