### PR TITLE
Fix logic for rest endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ You'll need the WordPress plugin for this MC Plugin to work - you can [get it he
 
 ## 1.4.5
 * Hotfix for [274](https://github.com/WooMinecraft/WooMinecraft/issues/274)
+* Fix pretty-permalink flag to actually use ugly permalinks for rest endpoints.
 
 ## 1.4.4
 * Fix logic for getting pending orders.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ You'll need the WordPress plugin for this MC Plugin to work - you can [get it he
 
 ## Changelog
 
+## 1.4.5
+* Hotfix for [274](https://github.com/WooMinecraft/WooMinecraft/issues/274)
+
 ## 1.4.4
 * Fix logic for getting pending orders.
 * Additional logging for pending orders.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.plugish.woominecraft</groupId>
     <artifactId>WooMinecraft</artifactId>
 
-    <version>1.4.4-${spigotVersion}</version>
+    <version>1.4.5-${spigotVersion}</version>
 
     <name>WooMinecraft</name>
     <description>A WooCommerce Minecraft Bridge</description>

--- a/src/main/java/com/plugish/woominecraft/WooMinecraft.java
+++ b/src/main/java/com/plugish/woominecraft/WooMinecraft.java
@@ -135,9 +135,9 @@ public final class WooMinecraft extends JavaPlugin {
 	public URL getSiteURL() throws Exception {
 		// Switches for pretty or non-pretty permalink support for REST urls.
 		boolean usePrettyPermalinks = this.getConfig().getBoolean( "prettyPermalinks" );
-		String baseUrl = getConfig().getString("url") + "/wp-json/wmc/v2/server/";
+		String baseUrl = getConfig().getString("url") + "/wp-json/wmc/v1/server/";
 		if ( ! usePrettyPermalinks ) {
-			baseUrl = getConfig().getString("url") + "/wp-json/wmc/v2/server/";
+			baseUrl = getConfig().getString("url") + "/wp-json/wmc/v1/server/";
 
 			String customRestUrl = this.getConfig().getString( "restBasePath" );
 			if ( ! customRestUrl.isEmpty() ) {

--- a/src/main/java/com/plugish/woominecraft/WooMinecraft.java
+++ b/src/main/java/com/plugish/woominecraft/WooMinecraft.java
@@ -137,7 +137,7 @@ public final class WooMinecraft extends JavaPlugin {
 		boolean usePrettyPermalinks = this.getConfig().getBoolean( "prettyPermalinks" );
 		String baseUrl = getConfig().getString("url") + "/wp-json/wmc/v1/server/";
 		if ( ! usePrettyPermalinks ) {
-			baseUrl = getConfig().getString("url") + "/wp-json/wmc/v1/server/";
+			baseUrl = getConfig().getString("url") + "/index.php?rest_route=/wmc/v1/server/";
 
 			String customRestUrl = this.getConfig().getString( "restBasePath" );
 			if ( ! customRestUrl.isEmpty() ) {


### PR DESCRIPTION
- Use v1 in rest endpoint base, not v2 - Fixes #274 
- Use ugly permalinks if `prettyPermalinks` is false